### PR TITLE
Use backported importlib_resources on Python 3.9

### DIFF
--- a/tests/example_package/test_example_module.py
+++ b/tests/example_package/test_example_module.py
@@ -1,7 +1,17 @@
 import os
+import sys
 
 from astropy.tests.helper import assert_quantity_allclose
-from importlib_resources import files
+
+try:
+    if sys.version_info[0] == 3 and sys.version_info[1] < 10:
+        # Python 3.9 version of importlib.resources.files behaves differently
+        from importlib_resources import files
+    else:
+        from importlib.resources import files
+except ModuleNotFoundError:
+    from importlib_resources import files
+
 from synphot import units
 from synphot.spectrum import BaseUnitlessSpectrum, SourceSpectrum, SpectralElement
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
The `importlib.resources.files()` interface in stdlib behaves differently under Python 3.9 than the backported version in `importlib_resources` and fails in the internals of constructing a `PosixPath`. The backported `importlib_resources` isn't available under Python 3.10 so we need to use the stdlib `importlib_resources` on that version.
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
Use `sys.version` to detect the Python version and use the backported `importlib_resources` on Python <3.9

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
